### PR TITLE
fix: handle a top-level error

### DIFF
--- a/cmd/kpack.go
+++ b/cmd/kpack.go
@@ -17,7 +17,7 @@ func NewKpackCmd() *cobra.Command {
 	var kpackCmd = &cobra.Command{
 		Use:   "kpack",
 		Short: "Create a kpack build on cluster",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("::debug:: kpack build")
 
 			fmt.Println("::debug:: tag", c.Tag)
@@ -33,8 +33,10 @@ func NewKpackCmd() *cobra.Command {
 
 			err := c.Build()
 			if err != nil {
-				fmt.Printf("::debug:: error creating build %+v\n", err)
+				fmt.Printf("::error:: error performing build %+v\n", err)
+				return err
 			}
+			return nil
 		},
 	}
 

--- a/pkg/kpack/build.go
+++ b/pkg/kpack/build.go
@@ -246,13 +246,13 @@ func DeleteBuild(ctx context.Context, cl client.Client, namespace string, name s
 	build := &v1alpha2.Build{}
 	err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, build)
 	if err != nil {
-		fmt.Printf("::debug:: error getting build: %+v\n", err)
+		fmt.Printf("::warning:: error getting build: %+v\n", err)
 		return
 	}
 
 	err = cl.Delete(ctx, build)
 	if err != nil {
-		fmt.Printf("::debug:: error deleting build %+v\n", err)
+		fmt.Printf("::warning:: error deleting build %+v\n", err)
 		return
 	}
 }


### PR DESCRIPTION
Top level errors will be reported with an "::error::" prefix and will cause the action to fail.